### PR TITLE
feat!: Dockerfile & GitHub Actions workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github/
+LICENCE
+README.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+ Please, type here Pull Request description.
+
+
+## Type of change
+
+ Please delete options that are not relevant.
+
+ - [ ] Bug fix (non-breaking change which fixes an issue)
+ - [ ] New feature (non-breaking change which adds functionality)
+ - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+ - [ ] This change requires a documentation update
+
+
+# How Has This Been Tested?
+
+ Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+ - [x] Test A - Run the code locally with `dry-run` mode;
+ - [x] Test B - Run the code on `devnet` environment;
+ - [x] Test C - ...
+
+## Notes
+
+ If you want to left some extra comment please type it here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@
 
  Please, type here Pull Request description.
 
-
 ## Type of change
 
  Please delete options that are not relevant.
@@ -12,8 +11,7 @@
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update
 
-
-# How Has This Been Tested?
+## How Has This Been Tested?
 
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,54 @@
+---
+name: "[Check] Code Hygiene"
+
+on:
+  pull_request:
+    branches: ["devnet", "testnet", "mainnet"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-code-hygiene:
+    name: Cargo
+    runs-on: self-hosted
+
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          components: rustfmt clippy rust-src
+
+      - name: Install needed tools
+        run: sudo apt-get install protobuf-compiler jq ripgrep libclang-dev libssl-dev -y
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Format check
+        run: |
+          rustup toolchain add nightly-x86_64-unknown-linux-gnu
+          rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+          cargo +nightly fmt -- --check
+
+      - name: Apply "cargo clippy" for suggestions and warnings for potential errors
+        run: cargo clippy --all-targets -- --deny warnings
+
+      - name: Clippy checks all features (exclude node and runtime)
+        run: |
+          set -o pipefail
+          cargo metadata --format-version=1 --no-deps \
+            | jq '.packages | .[] | .name' \
+            | rg --invert-match 'data-storage-(node|runtime)' \
+            | xargs -I {} cargo clippy --package {} --all-targets --all-features -- --deny warnings --deny missing_docs

--- a/.github/workflows/release-binary.yaml
+++ b/.github/workflows/release-binary.yaml
@@ -1,0 +1,116 @@
+name: "[Release] Binary (Linux & MacOS)"
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux:
+    runs-on: self-hosted
+
+    outputs:
+      artifact: data-storage-node-${{ runner.os }}-${{ runner.arch }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: apt-get update && apt install protobuf-compiler libclang-dev libssl-dev -y
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Fetch
+        run: cargo fetch
+
+      - name: Build
+        run: cargo build --locked --release --allow warnings
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-storage-node-${{ runner.os }}-${{ runner.arch }}
+          path: ./target/release/data-storage-node
+          if-no-files-found: error
+
+  build-macos:
+    runs-on: macos-latest
+
+    needs: define-variables
+
+    outputs:
+      artifact: data-storage-node-${{ runner.os }}-${{ runner.arch }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew upgrade rustup
+          brew install protobuf
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Fetch
+        run: cargo fetch
+
+      - name: Build
+        run: cargo build --locked --release --allow warnings
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-storage-node-${{ runner.os }}-${{ runner.arch }}
+          path: ./target/release/data-storage-node
+          if-no-files-found: error
+
+  publish:
+    runs-on: self-hosted
+
+    needs: [build-linux, build-macos]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set GitHub commit short SHA
+        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
+      - name: Set GitHub branch
+        run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Download Linux binary file
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-linux.outputs.artifact }}
+          path: release/linux
+
+      - name: Download MacOS binary file
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-macos.outputs.artifact }}
+          path: release/macos
+
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        with:
+          name: binary-release-${{ env.BRANCH }}-${{ env.SHORT_SHA }}
+          files: |
+            LICENSE
+            ./release/linux/${{ needs.build-linux.outputs.artifact }}
+            ./release/macos/${{ needs.build-macos.outputs.artifact }}

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,0 +1,43 @@
+name: "[Release] Docker"
+
+on:
+  workflow_dispatch:
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+  DOCKERHUB_REPOSITORY: ${{ vars.DOCKERHUB_REPOSITORY }}
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set GitHub commit short SHA
+        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
+      - name: Set GitHub branch
+        run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Login to OVH (Harbor) private registry
+        run: |
+          docker login \
+            --username ${{ env.DOCKERHUB_USERNAME }} \
+            --password ${{ env.DOCKERHUB_PASSWORD }} \
+            docker.io
+
+      - name: Build Docker image(s)
+        run: |
+          docker build \
+            -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}-latest \
+            -t ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}-${{ env.SHORT_SHA } \
+            .
+
+      - name: Push Docker image(s)
+        run: |
+          docker push \
+            --all-tags \
+            ${{ env.DOCKERHUB_REPOSITORY }}

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -1,0 +1,54 @@
+name: "[Release] Runtime"
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler jq
+
+      - name: Fetch
+        run: cargo fetch
+
+      - name: Build
+        run: cargo build --all --locked --release
+
+      - name: Define variables
+        id: define-variables
+        run: |
+          commit_sha=${{ github.sha }}
+          echo "commit_sha=${commit_sha:0:7}" >> "$GITHUB_OUTPUT"
+          echo "release_name=$(./target/release/data-storage-node runtime-version | jq '[.spec_name, .spec_version, .authoring_version, .state_version, .transaction_version, .apis_hash[:16]] | join("-")')" >> "$GITHUB_OUTPUT"
+
+      - uses: softprops/action-gh-release@v2
+        env:
+          release_name: ${{ steps.define-variables.outputs.release_name }}
+          commit_sha: ${{ steps.define-variables.outputs.commit_sha }}
+        with:
+          name: runtime-release-${{ env.release_name }}-${{ env.commit_sha }}
+          files: |
+            LICENSE
+            ./target/release/wbuild/data-storage-runtime/data_storage_runtime.wasm
+            ./target/release/wbuild/data-storage-runtime/data_storage_runtime.compact.wasm
+            ./target/release/wbuild/data-storage-runtime/data_storage_runtime.compact.compressed.wasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: build application binary
+FROM rust:1.84.0 AS builder
+
+# Working directory
+WORKDIR /app
+
+# Copy application files
+COPY . /app
+
+# Install dependencies
+RUN apt-get update && apt-get install protobuf-compiler libclang-dev libssl-dev -y
+
+# Setup Rust toolchain
+RUN rustup target add wasm32-unknown-unknown
+RUN rustup component add rustfmt clippy rust-src
+
+# Fetch
+RUN cargo fetch
+
+# Build
+RUN cargo build --locked --release
+
+# Stage 2: use small image as a "base" image
+FROM ubuntu:24.10
+
+# Working directory
+WORKDIR /app
+
+# Copy built binary file
+COPY --from=builder /app/target/release/lib* /app/target/release/data-storage-node /app/bin/
+
+# Expose default ports (P2P, WebSocket, RPC, Prometheus)
+EXPOSE 30333 9933 9944 9615
+
+# Specify entrypoint
+ENTRYPOINT ["/app/bin/data-storage-node"]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 /// Sub-commands supported by the collator.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
     /// Build a chain specification.

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -194,14 +194,11 @@ pub fn run() -> Result<()> {
                     cmd.run(partials.client)
                 }),
                 #[cfg(not(feature = "runtime-benchmarks"))]
-                BenchmarkCmd::Storage(_) => {
-                    return Err(sc_cli::Error::Input(
-                        "Compile with --features=runtime-benchmarks \
+                BenchmarkCmd::Storage(_) => Err(sc_cli::Error::Input(
+                    "Compile with --features=runtime-benchmarks \
 						to enable storage benchmarks."
-                            .into(),
-                    )
-                    .into())
-                },
+                        .into(),
+                )),
                 #[cfg(feature = "runtime-benchmarks")]
                 BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
                     let partials = new_partial(&config)?;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -154,6 +154,7 @@ fn build_import_queue(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn start_consensus(
     client: Arc<ParachainClient>,
     block_import: ParachainBlockImport,


### PR DESCRIPTION
## Description

 The main task is to add release automation to release binary, runtime and Docker image. Locally tested Docker image build process - everything is working OK, I can see the binary version and run the node.

 Regarding binary and runtime releases - I decided to use the same approach as applied for `atleta-node`, but:

 * Applied `workflow_dispatch` for now to run it manually besides of `check.yaml` workflow;
 * Release naming for binary - "binary-release-[github_branch]-[short_sha]", runtime - "runtime-release-[github_branch]-[short_sha]". For binary decided do not archive artifacts, just name the binary with the name "data-storage-node-[os_platform]-[os_architecture]".

 > **Note**: this changes won't affect the application core functionality, just add an automation.

 Summary:
  - Added Dockerfile and .dockerignore;
  - Added GitHub Actions workflows;
  - Added pull request template.

## Type of change

 Please delete options that are not relevant.

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update

## How Has This Been Tested?

 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 - [ ] Test A - Run the code locally with `dry-run` mode;
 - [ ] Test B - Run the code on `devnet` environment;
 - [ ] Test C - ...

## Notes

 If you want to left some extra comment please type it here.